### PR TITLE
Add support for $ite_t and $ite_f

### DIFF
--- a/basics_minimal.dk
+++ b/basics_minimal.dk
@@ -1,8 +1,11 @@
+#REQUIRE cc.
+#REQUIRE dk_bool.
+#REQUIRE dk_logic.
+#REQUIRE dk_tuple.
+
 (; Ceci est une version minimale écrite à la main du fichier
 habituellement généré basics.dk. Ce fichier permet de tester Zenon
 indépendamment de FoCaLiZe. ;)
-
-#NAME basics.
 
 def Is_true := dk_logic.ebP.
 

--- a/cc.dk
+++ b/cc.dk
@@ -1,4 +1,3 @@
-#NAME cc.
 (; Calculus of Construction embedded into Lambda-Pi Modulo ;)
 
 uT : Type.

--- a/dk_bool.dk
+++ b/dk_bool.dk
@@ -1,4 +1,4 @@
-#NAME dk_bool.
+#REQUIRE cc.
 
 (; Bool ;)
 (; Declaration ;)

--- a/dk_logic.dk
+++ b/dk_logic.dk
@@ -1,4 +1,5 @@
-#NAME dk_logic.
+#REQUIRE cc.
+#REQUIRE dk_bool.
 
 (; Impredicative prop ;)
 

--- a/dk_tuple.dk
+++ b/dk_tuple.dk
@@ -1,4 +1,4 @@
-#NAME dk_tuple.
+#REQUIRE cc.
 
 prod : cc.uT -> cc.uT -> cc.uT.
 Prod : cc.uT -> cc.uT -> Type.

--- a/expr.ml
+++ b/expr.ml
@@ -738,6 +738,12 @@ and eeq a b =
     let s = tvar "=" (earrow [t; t] type_prop) in
     eapp (s, [a; b])
 
+and eite_t p a b =
+  let t = get_type a in
+  let t' = get_type p in
+  let s = tvar "$ite_t" (earrow [t'; t; t] t) in
+  eapp (s, [p; a; b])
+
 and substitute_unsafe map e =
   let aux f map v body =
       let t = substitute_unsafe map (get_type v) in

--- a/expr.mli
+++ b/expr.mli
@@ -59,6 +59,7 @@ val emeta : expr -> expr;;
 val eapp : expr * expr list -> expr;;
 
 val eeq : expr -> expr -> expr;;
+val eite_t : expr -> expr -> expr -> expr;;
 val estring : expr;;
 
 (* Prop construction *)

--- a/lextptp.mll
+++ b/lextptp.mll
@@ -73,6 +73,7 @@ rule token = parse
   | "cnf"            { INPUT_CLAUSE }
   | "fof"            { INPUT_FORMULA }
   | "tff"            { INPUT_TFF_FORMULA }
+  | "$ite_f"	     { ITE_F }
   | "$o"             { PROP }
   | "$true"          { TRUE }
   | "$false"         { FALSE }

--- a/parsetptp.mly
+++ b/parsetptp.mly
@@ -40,6 +40,7 @@ let cnf_to_formula l =
 %token IMPLY
 %token RIMPLY
 %token AND
+%token ITE_F
 %token OR
 %token NOT
 %token PROP
@@ -137,6 +138,7 @@ expr:
   | REAL                               { Arith.mk_real $1 }
   | expr EQSYM expr                    { eeq $1 $3 }
   | expr NEQSYM expr                   { enot (eeq $1 $3) }
+  | OPEN expr CLOSE                    { $2 }
 ;
 arguments:
   | OPEN expr_list CLOSE         { $2 }
@@ -157,6 +159,7 @@ formula:
   | unit_formula NOR formula           { enot (eor ($1, $3)) }
   | unit_formula NAND formula          { enot (eand ($1, $3)) }
 ;
+
 type_def:
     | OPEN type_def CLOSE        { $2 }
     | LIDENT COLON tff_type_sig  { eapp (tvar_none "#", [tvar_none $1; $3]) }
@@ -168,6 +171,7 @@ unit_formula:
                                    { mk_quant eex $3 $6 }
   | NOT unit_formula               { enot ($2) }
   | OPEN formula CLOSE             { $2 }
+  | ITE_F OPEN formula COMMA formula COMMA formula CLOSE { let a,b,c = $3,$5,$7 in eor(eand(enot a, b), eand(a,c)) }
   | atom                           { $1 }
 ;
 var_list:

--- a/typetptp.ml
+++ b/typetptp.ml
@@ -185,6 +185,11 @@ let rec type_tff_app env expected e =
   | Eapp(Evar("$int", _), [], _) -> Arith.type_int, env
   | Eapp(Evar("$rat", _), [], _) -> Arith.type_rat, env
   | Eapp(Evar("$real", _), [], _) -> Arith.type_real, env
+  | Eapp(Evar("$ite_t", _), [p; a; b], _) ->
+     let p', env' = type_tff_prop env p in
+     let a', env'' = type_tff_term env' a in
+     let b', env''' = type_tff_term env'' b in
+     eite_t p' a' b', env'''
   (* Application typechecking *)
   | Eapp(Evar("=", _), [a; b], _) ->
     let a', env' = type_tff_term env a in

--- a/zen.dk
+++ b/zen.dk
@@ -1,4 +1,5 @@
-#NAME zen.
+#REQUIRE cc.
+#REQUIRE dk_logic.
 
 (; Logic for Zenon Modulo ;)
 

--- a/zen.lp
+++ b/zen.lp
@@ -1,161 +1,166 @@
 // Logic for Zenon Modulo
 
 
-set declared "τ"
-set declared "ι"
-set declared "π"
-set declared "⊤"
-set declared "⊥"
-set declared "¬"
-set declared "∀"
-set declared "∃"
+// set declared "τ"
+// set declared "ι"
+// set declared "π"
+// set declared "⊤"
+// set declared "⊥"
+// set declared "¬"
+// set declared "∀"
+// set declared "∃"
 
-symbol Prop  : TYPE
-symbol Type  : TYPE
+symbol Prop  : TYPE;
+symbol Type  : TYPE;
 
-injective symbol π : Prop → TYPE
-injective symbol τ : Type → TYPE
+injective symbol π : Prop → TYPE;
+injective symbol τ : Type → TYPE;
 
-constant symbol ι  : Type
+constant symbol ι  : Type;
 
 // Symbols
 
-symbol ⊤ : Prop
-symbol ⊥ : Prop
+symbol ⊤ : Prop;
+symbol ⊥ : Prop;
 
-symbol ¬ : Prop → Prop
-symbol {|and|} : Prop → Prop → Prop
-symbol or  : Prop → Prop → Prop
-symbol imp : Prop → Prop → Prop
-symbol eqv : Prop → Prop → Prop
+symbol ¬ : Prop → Prop;
+symbol {|and|} : Prop → Prop → Prop;
+symbol or  : Prop → Prop → Prop;
+symbol imp : Prop → Prop → Prop;
+symbol eqv : Prop → Prop → Prop;
 
-set infix right 5 "⇒" ≔ imp
-set infix right 10 "∧" ≔ {|and|}
-set infix right 9 "∨" ≔ or
-set infix left 10 "⇔" ≔ eqv
+symbol ⇒ ≔ imp;
+symbol ∧ ≔ {|and|};
+symbol ∨ ≔ or;
+symbol ⇔ ≔ eqv;
 
-constant symbol select : Π (a : Type), τ a
+notation ⇒ infix right 5;
+notation ∧ infix right 10;
+notation ∨ infix right 9;
+notation ⇔ infix left 10;
 
-symbol ∀ {a} : (τ a → Prop) → Prop
-symbol ∃ {a} : (τ a → Prop) → Prop
+constant symbol select : Π (a : Type), τ a;
 
-set quantifier ∀
-set quantifier ∃
+symbol ∀ [a] : (τ a → Prop) → Prop;
+symbol ∃ [a] : (τ a → Prop) → Prop;
 
-symbol foralltype : (Type → Prop) → Prop
-symbol existstype : (Type → Prop) → Prop
+notation ∀ quantifier;
+notation ∃ quantifier;
 
-symbol equal  {a} : τ a → τ a → Prop
-set infix 12 "=" ≔ equal
+symbol foralltype : (Type → Prop) → Prop;
+symbol existstype : (Type → Prop) → Prop;
 
-symbol Rfalse : π ⊥ → π ⊥
+symbol equal [a] : τ a → τ a → Prop;
+symbol = [a] : τ a → τ a → Prop ≔ equal;
+notation = infix 12;
 
-symbol Rnottrue : π (¬ ⊤) → π ⊥
+symbol Rfalse : π ⊥ → π ⊥;
 
-symbol Raxiom : Π (p : Prop), π p → π (¬ p) → π ⊥
+symbol Rnottrue : π (¬ ⊤) → π ⊥;
 
-symbol Rnoteq : Π (a : Type) (t : τ a), π (¬ (t = t)) → π ⊥
+symbol Raxiom : Π (p : Prop), π p → π (¬ p) → π ⊥;
 
-symbol Reqsym a (t u : τ a) : π (t = u) → π (¬ (u = t)) → π ⊥
+symbol Rnoteq : Π (a : Type) (t : τ a), π (¬ (t = t)) → π ⊥;
 
-symbol Rcut p : (π p → π ⊥) → (π (¬ p) → π ⊥) → π ⊥
+symbol Reqsym a (t u : τ a) : π (t = u) → π (¬ (u = t)) → π ⊥;
 
-symbol Rnotnot p : (π p → π ⊥) → π (¬ (¬ p)) → π ⊥
+symbol Rcut p : (π p → π ⊥) → (π (¬ p) → π ⊥) → π ⊥;
 
-symbol Rand p q : (π p → π q → π ⊥) → π (p ∧ q) → π ⊥
+symbol Rnotnot p : (π p → π ⊥) → π (¬ (¬ p)) → π ⊥;
 
-symbol Ror p q : (π p → π ⊥) → (π q → π ⊥) → π (p ∨ q) → π ⊥
+symbol Rand p q : (π p → π q → π ⊥) → π (p ∧ q) → π ⊥;
 
-symbol Rimply p q :  (π (¬ p) → π ⊥) → (π q → π ⊥) → π (p ⇒ q) → π ⊥
+symbol Ror p q : (π p → π ⊥) → (π q → π ⊥) → π (p ∨ q) → π ⊥;
 
-symbol Requiv p q : 
-  (π (¬ p) → π (¬ q) → π ⊥) → (π p → π q → π ⊥) → π (p ⇔ q) → π ⊥
+symbol Rimply p q :  (π (¬ p) → π ⊥) → (π q → π ⊥) → π (p ⇒ q) → π ⊥;
 
-symbol Rnotand p q : 
-  (π (¬ p) → π ⊥) → (π (¬ q) → π ⊥) → π (¬ (p ∧ q)) → π ⊥
+symbol Requiv p q :
+  (π (¬ p) → π (¬ q) → π ⊥) → (π p → π q → π ⊥) → π (p ⇔ q) → π ⊥;
 
-symbol Rnotor p q : (π (¬ p) → π (¬ q) → π ⊥) → π (¬ (or p q)) → π ⊥
+symbol Rnotand p q :
+  (π (¬ p) → π ⊥) → (π (¬ q) → π ⊥) → π (¬ (p ∧ q)) → π ⊥;
 
-symbol Rnotimply p q : (π p → π (¬ q) → π ⊥) → π (¬ (imp p q)) → π ⊥
+symbol Rnotor p q : (π (¬ p) → π (¬ q) → π ⊥) → π (¬ (or p q)) → π ⊥;
+
+symbol Rnotimply p q : (π p → π (¬ q) → π ⊥) → π (¬ (imp p q)) → π ⊥;
 
 symbol Rnotequiv p q :
-  (π (¬ p) → π q → π ⊥) → (π p → π (¬ q) → π ⊥) → π (¬ (p ⇔ q)) → π ⊥
+  (π (¬ p) → π q → π ⊥) → (π p → π (¬ q) → π ⊥) → π (¬ (p ⇔ q)) → π ⊥;
 
-symbol Rex a p : (Π (t : τ a), π (p t) → π ⊥) → π (∃ p) → π ⊥
+symbol Rex a p : (Π (t : τ a), π (p t) → π ⊥) → π (∃ p) → π ⊥;
 
-symbol Rall a p t : (π (p t) → π ⊥) → π (@∀ a p) → π ⊥
+symbol Rall a p t : (π (p t) → π ⊥) → π (@∀ a p) → π ⊥;
 
-symbol Rnotex a (p : (τ a → Prop)) (t : τ a) : 
-  (π (¬ (p t)) → π ⊥) → π (¬ (∃ p)) → π ⊥
+symbol Rnotex a (p : (τ a → Prop)) (t : τ a) :
+  (π (¬ (p t)) → π ⊥) → π (¬ (∃ p)) → π ⊥;
 
-symbol Rnotall a p : (Π (t : τ a), π (¬ (p t)) → π ⊥) → π (¬ (@∀ a p)) → π ⊥
+symbol Rnotall a p : (Π (t : τ a), π (¬ (p t)) → π ⊥) → π (¬ (@∀ a p)) → π ⊥;
 
-symbol Rextype (p : (Type → Prop)) : 
-  (Π (a : Type), π (p a) → π ⊥) → π (existstype p) → π ⊥
+symbol Rextype (p : (Type → Prop)) :
+  (Π (a : Type), π (p a) → π ⊥) → π (existstype p) → π ⊥;
 
 symbol Ralltype (p : (Type → Prop)) a :
-  (π (p a) → π ⊥) → π (foralltype p) → π ⊥
+  (π (p a) → π ⊥) → π (foralltype p) → π ⊥;
 
-symbol Rnotextype (p : (Type → Prop)) a : 
-  (π (¬ (p a)) → π ⊥) → π (¬ (existstype p)) → π ⊥
+symbol Rnotextype (p : (Type → Prop)) a :
+  (π (¬ (p a)) → π ⊥) → π (¬ (existstype p)) → π ⊥;
 
-symbol Rnotalltype (p : (Type → Prop)) : 
-  (Π (a : Type), π (¬ (p a)) → π ⊥) → π (¬ (foralltype p)) → π ⊥
+symbol Rnotalltype (p : (Type → Prop)) :
+  (Π (a : Type), π (¬ (p a)) → π ⊥) → π (¬ (foralltype p)) → π ⊥;
 
 symbol Rsubst a (p : (τ a → Prop)) (t1 t2 : τ a) :
-  (π (¬ (t1 = t2)) → π ⊥) → (π (p t2) → π ⊥) → π (p t1) → π ⊥
+  (π (¬ (t1 = t2)) → π ⊥) → (π (p t2) → π ⊥) → π (p t1) → π ⊥;
 
 symbol Rconglr a (p : (τ a → Prop)) (t1 t2 : τ a) :
-  (π (p t2) → π ⊥) → π (p t1) → π (t1 = t2) → π ⊥
+  (π (p t2) → π ⊥) → π (p t1) → π (t1 = t2) → π ⊥;
 
 symbol Rcongrl a (p : (τ a → Prop)) (t1 t2 : τ a) :
-  (π (p t2) → π ⊥) → π (p t1) → π (t2 = t1) → π ⊥
+  (π (p t2) → π ⊥) → π (p t1) → π (t2 = t1) → π ⊥;
 
 // rule π ⊥ ↪ Π p, π p
-rule π (¬ $p) ↪ π $p → π ⊥
-rule π ⊤ ↪ Π p, π p → π p
-rule π (imp $p $q) ↪ π $p → π $q
-rule π (or $p $q) ↪ Π x, (π $p → π x) → (π $q → π x) → π x
-rule π (eqv $p $q) ↪ Π x, (π (imp $p $q) → π (imp $q $p) → π x) → π x
-rule π (@equal $a $t $v) ↪ Π(x:τ $a → Prop), π (x $t) → π (x $v)
-rule π ({|and|} $p $q) ↪ Π x, (π $p → π $q → π x) → π x
-rule π (@∃ $a $p) ↪ Π P, (Π(x : τ $a), π ($p x) → π P) → π P
-rule π (@∀ $a $p) ↪ Π x, π ($p x)
+rule π (¬ $p) ↪ π $p → π ⊥;
+rule π ⊤ ↪ Π p, π p → π p;
+rule π (imp $p $q) ↪ π $p → π $q;
+rule π (or $p $q) ↪ Π x, (π $p → π x) → (π $q → π x) → π x;
+rule π (eqv $p $q) ↪ Π x, (π (imp $p $q) → π (imp $q $p) → π x) → π x;
+rule π (@equal $a $t $v) ↪ Π(x:τ $a → Prop), π (x $t) → π (x $v);
+rule π ({|and|} $p $q) ↪ Π x, (π $p → π $q → π x) → π x;
+rule π (@∃ $a $p) ↪ Π P, (Π(x : τ $a), π ($p x) → π P) → π P;
+rule π (@∀ $a $p) ↪ Π x, π ($p x);
 
 
-symbol nnpp (p : Prop) : π (¬ (¬ p)) → π p
+symbol nnpp (p : Prop) : π (¬ (¬ p)) → π p;
 
-rule nnpp (¬ $a) $pr $q ↪ $pr (λ H1, H1 $q)
-rule nnpp (imp $a $b) $pr $q ↪ nnpp $b (λ H1, $pr (λ H2, H1 (H2 $q)))
+rule nnpp (¬ $a) $pr $q ↪ $pr (λ H1, H1 $q);
+rule nnpp (imp $a $b) $pr $q ↪ nnpp $b (λ H1, $pr (λ H2, H1 (H2 $q)));
 rule nnpp (or $a $b) $pr $P $pa $pb ↪
-  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $pa $pb)))
+  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $pa $pb)));
 rule nnpp (eqv $a $b) $pr $P $pab ↪
-  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $pab)))
+  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $pab)));
 rule nnpp (equal $t $v) $pr $P $pt ↪
-  nnpp ($P $v) (λ H1 : π (¬ ($P $v)), $pr (λ H2, H1 (H2 $P $pt)))
+  nnpp ($P $v) (λ H1 : π (¬ ($P $v)), $pr (λ H2, H1 (H2 $P $pt)));
 rule nnpp ({|and|} $a $b) $pr $P $pab ↪
-  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $pab)))
+  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $pab)));
 rule nnpp (∃ $a) $pr $P $paP ↪
-  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $paP)))
-rule nnpp (∀ $a) $pr $t ↪ nnpp ($a $t) (λ H1 : π (¬ ($a $t)), $pr (λ H2, H1 (H2 $t)))
-rule nnpp ⊥ $pr ↪ $pr (λ z, z)
-rule nnpp $a[] (λ H1, H1 (nnpp $a[] (λ H2, $K[H1;H2]))) ↪
-  nnpp $a[] (λ H1, $K[H1;H1])
-rule nnpp $a (λ H1, H1 $K[]) ↪ $K[]
+  nnpp $P (λ H1 : π (¬ $P), $pr (λ H2, H1 (H2 $P $paP)));
+rule nnpp (∀ $a) $pr $t ↪ nnpp ($a $t) (λ H1 : π (¬ ($a $t)), $pr (λ H2, H1 (H2 $t)));
+rule nnpp ⊥ $pr ↪ $pr (λ z, z);
+rule nnpp $a.[] (λ H1, H1 (nnpp $a.[] (λ H2, $K.[H1;H2]))) ↪
+  nnpp $a.[] (λ H1, $K.[H1;H1]);
+rule nnpp $a (λ H1, H1 $K.[]) ↪ $K.[];
 
-definition bot (pr : π ⊥) (p : Prop) : π p ≔
-  nnpp p (λ _, pr)
+symbol bot (pr : π ⊥) (p : Prop) : π p ≔
+  nnpp p (λ _, pr);
 
-definition xmid (p z : Prop) (pp: π p → π z) (pnp : π (¬ p) → π z) : π z ≔
-  nnpp z (λ H2, H2 (pp (nnpp p (λ H3, H2 (pnp H3)))))
-  
+symbol xmid (p z : Prop) (pp: π p → π z) (pnp : π (¬ p) → π z) : π z ≔
+  nnpp z (λ H2, H2 (pp (nnpp p (λ H3, H2 (pnp H3)))));
 
 // usefull lemmas to prove rules
 
-definition true_intro : π ⊤
-             ≔ λ (p : Prop) (x : π p), x
+symbol true_intro : π ⊤
+             ≔ λ (p : Prop) (x : π p), x;
 
-definition lemme_contraposition (p : Prop)
+symbol lemme_contraposition (p : Prop)
                       (q : Prop)
 : (π (imp p q) →
    π (imp (¬ q) (¬ p)))
@@ -163,35 +168,35 @@ definition lemme_contraposition (p : Prop)
   λ (H1 : π (imp p q))
   (H2 : π (¬ q))
      (H3 : π p),
-	H2 (H1 H3)
+	H2 (H1 H3);
 
-definition lemme_equiv_1 (p : Prop)
+symbol lemme_equiv_1 (p : Prop)
 	       (q : Prop)
 	       (H5 : π q → π p)
 	       (H2 : π p → π (¬ q))
 	       (HQ : π q)
 : π (¬ q)
 ≔
-  H2 (H5 HQ)
+  H2 (H5 HQ);
 
-definition lemme_equiv_2 (p : Prop)
+symbol lemme_equiv_2 (p : Prop)
  	       (q : Prop)
 	       (H5 : π q → π p)
 	       (H2 : π p → π (¬ q))
 : π (¬ q)
 ≔
-  λ (HQ : π q), lemme_equiv_1 p q H5 H2 HQ HQ
+  λ (HQ : π q), lemme_equiv_1 p q H5 H2 HQ HQ;
 
-definition lemme_equiv_3 (p : Prop)
+symbol lemme_equiv_3 (p : Prop)
 	       (q : Prop)
 	       (H5 : π q → π p)
 	       (H2 : π p → π (¬ q))
 	       (H4 : π p → π q)
 : π (¬ p)
 ≔
-  lemme_contraposition p q H4 (lemme_equiv_2 p q H5 H2)
+  lemme_contraposition p q H4 (lemme_equiv_2 p q H5 H2);
 
-definition lemme_equiv_4 (p : Prop)
+symbol lemme_equiv_4 (p : Prop)
 	       (q : Prop)
 	       (H5 : π q → π p)
 	       (H2 : π p → π (¬ q))
@@ -199,9 +204,9 @@ definition lemme_equiv_4 (p : Prop)
 	       (H1 : π (¬ p) → π (¬ (¬ q)))
 : π (¬ (¬ q))
 ≔
-  H1 (lemme_equiv_3 p q H5 H2 H4)
+  H1 (lemme_equiv_3 p q H5 H2 H4);
 
-definition lemme_notor_1 (p : Prop)
+symbol lemme_notor_1 (p : Prop)
 	       (q : Prop)
 : π p → π (or p q)
 ≔
@@ -209,9 +214,9 @@ definition lemme_notor_1 (p : Prop)
     (z : Prop)
     (H2 : (π p → π z))
 	  (H3 : (π q → π z)),
-	   H2 H1
+	   H2 H1;
 
-definition lemme_notor_2 (p : Prop)
+symbol lemme_notor_2 (p : Prop)
 	       (q : Prop)
 : π q → π (or p q)
 ≔
@@ -219,47 +224,47 @@ definition lemme_notor_2 (p : Prop)
     (z : Prop)
     (H2 : (π p → π z))
 	  (H3 : (π q → π z)),
-	   H3 H1
+	   H3 H1;
 
-definition lemme_notor_3 (p : Prop)
+symbol lemme_notor_3 (p : Prop)
 	       (q : Prop)
 	       (H2 : π (¬ (or p q)))
 : π (¬ p)
 ≔
-  lemme_contraposition p (or p q) (lemme_notor_1 p q) H2
+  lemme_contraposition p (or p q) (lemme_notor_1 p q) H2;
 
-definition lemme_notor_4 (p : Prop)
+symbol lemme_notor_4 (p : Prop)
 	       (q : Prop)
 	       (H2 : π (¬ (or p q)))
 : π (¬ q)
 ≔
-  lemme_contraposition q (or p q) (lemme_notor_2 p q) H2
+  lemme_contraposition q (or p q) (lemme_notor_2 p q) H2;
 
-definition lemme_notimply_1 (p : Prop)
+symbol lemme_notimply_1 (p : Prop)
 	          (q : Prop)
 	          (H2 : π (¬ (imp p q)))
 : π (¬ q)
 ≔
   λ (H3 : π q),
-  H2 (λ (H4 : π p), H3)
+  H2 (λ (H4 : π p), H3);
 
-definition lemme_notimply_2 (p : Prop)
+symbol lemme_notimply_2 (p : Prop)
 	          (q : Prop)
 	          (H1 : π p → π (¬ (¬ q)))
 	          (H2 : π (¬ (imp p q)))
 : π (¬ p)
 ≔
   λ (H3 : π p),
-    (H1 H3) (lemme_notimply_1 p q H2)
+    (H1 H3) (lemme_notimply_1 p q H2);
 
-definition lemme_notimply_3 (p : Prop)
+symbol lemme_notimply_3 (p : Prop)
 	          (q : Prop)
 	          (H3 : π (¬ p))
 : π (imp p q)
 ≔
-  λ (H4 : π p), bot (H3 H4) q
+  λ (H4 : π p), bot (H3 H4) q;
 
-definition lemme_notequiv_1 (p : Prop)
+symbol lemme_notequiv_1 (p : Prop)
                   (q : Prop)
                   (H2 : π p → π (¬ (¬ q)))
                   (H3 : π (¬ (eqv p q)))
@@ -271,21 +276,21 @@ definition lemme_notequiv_1 (p : Prop)
                     (H4 : (π (imp p q) →
                             π (imp q p) →
                             π z)),
-                      H4 (λ (__ : π p), HQ) (λ (__ : π q), HP)))
+                      H4 (λ (__ : π p), HQ) (λ (__ : π q), HP)));
 
 // πs of LLπ Rules
 
-rule Rfalse ↪ λ (x : π ⊥), x
+rule Rfalse ↪ λ (x : π ⊥), x;
 
-rule Rnottrue ↪ λ (H : π (¬ ⊤)), H true_intro
+rule Rnottrue ↪ λ (H : π (¬ ⊤)), H true_intro;
 
-rule Raxiom $p ↪ λ (H : π $p) (CH : π (¬ $p)), CH H
+rule Raxiom $p ↪ λ (H : π $p) (CH : π (¬ $p)), CH H;
 
 rule Rnoteq $a $t ↪
   λ (H1 : π (¬ ($t = $t))),
      H1 (λ (z : (τ $a → Prop)),
 	     (λ (H2 : π (z $t)),
-	          H2))
+	          H2));
 
 rule Reqsym $a $t $u ↪
   λ (H1 : π ($t = $u))
@@ -296,34 +301,34 @@ rule Reqsym $a $t $u ↪
 		            (imp (z x) (z $t)))
 		     (λ (H4 : π (z $t)),
 		      H4)
-		     H3)
+		     H3);
 
 rule Rcut $p ↪
   λ (H1 : (π $p → π ⊥))
     (H2 : (π (¬ $p) → π ⊥)),
-     H2 H1
+     H2 H1;
 
 rule Rnotnot $p ↪
   λ (H1 : (π $p → π ⊥))
     (H2 : π (¬ (¬ $p))),
-     H2 H1
+     H2 H1;
 
 rule Rand $p $q ↪
   λ (H1 : (π $p → π $q → π ⊥))
     (H2 : π ({|and|} $p $q)),
-     H2 ⊥ H1
+     H2 ⊥ H1;
 
 rule Ror $p $q ↪
   λ (H1 : (π $p → π ⊥))
     (H2 : (π $q → π ⊥))
     (H3 : π (or $p $q)),
-	   H3 ⊥ H1 H2
+	   H3 ⊥ H1 H2;
 
 rule Rimply $p $q ↪
   λ (H1 : (π (¬ $p) → π ⊥))
     (H2 : (π $q → π ⊥))
     (H3 : π (imp $p $q)),
-     H1 (lemme_contraposition $p $q H3 H2)
+     H1 (lemme_contraposition $p $q H3 H2);
 
 rule Requiv $p $q ↪
   λ (H1 : (π (¬ $p) → π (¬ $q) → π ⊥))
@@ -332,7 +337,7 @@ rule Requiv $p $q ↪
 	   H3 ⊥
              (λ (H4 : (π $p → π $q))
 	              (H5 : (π $q → π $p)),
-		  lemme_equiv_4 $p $q H5 H2 H4 H1 (lemme_equiv_2 $p $q H5 H2))
+		  lemme_equiv_4 $p $q H5 H2 H4 H1 (lemme_equiv_2 $p $q H5 H2));
 
 rule Rnotand $p $q ↪
   λ (H1 : (π (¬ $p) → π ⊥))
@@ -342,12 +347,12 @@ rule Rnotand $p $q ↪
                H2 (λ (H6 : π $q),
                    H3 (λ (z : Prop),
                        (λ (H4 : (π $p → π $q → π z)),
-                        H4 H5 H6))))
+                        H4 H5 H6))));
 
 rule Rnotor $p $q ↪
   λ (H1 : (π (¬ $p) → π (¬ $q) → π ⊥))
     (H2 : π (¬ (or $p $q))),
-     H1 (lemme_notor_3 $p $q H2) (lemme_notor_4 $p $q H2)
+     H1 (lemme_notor_3 $p $q H2) (lemme_notor_4 $p $q H2);
 
 // [p : Prop, q : Prop] Rnotimply p q ↪
 //   H1 : (π p → π (¬ q) → π ⊥)
@@ -382,7 +387,7 @@ rule Rnotimply $p $q ↪
      H2 (λ (H3 : π $p),
             bot ((H1 H3) (λ (H4 : π $q),
                         H2 (λ (H5 : π $p),
-                               H4))) $q)
+                               H4))) $q);
 
 
 rule Rnotequiv $p $q ↪
@@ -394,17 +399,17 @@ rule Rnotequiv $p $q ↪
                   (H4 : (π (imp $p $q) → π (imp $q $p) → π z)),
                       H4 (λ (HP : π $p), bot (HNP HP) $q)
                             (λ (HQ : π $q), bot (H1 HNP HQ) $p)))
-           (lemme_notequiv_1 $p $q H2 H3)
+           (lemme_notequiv_1 $p $q H2 H3);
 
 rule Rex $a $p ↪
   λ (H1 : (Π (t : τ $a), π ($p t) → π ⊥))
     (H2 : π (@∃ $a $p)),
-     H2 ⊥ H1
+     H2 ⊥ H1;
 
 rule Rall $a $p $t ↪
   λ (H1 : (π ($p $t) → π ⊥))
     (H2 : π (@∀ $a $p)),
-     H1 (H2 $t)
+     H1 (H2 $t);
 
 rule Rnotex $a $p $t ↪
   λ (H1 : (π (¬ ($p $t)) → π ⊥))
@@ -412,13 +417,13 @@ rule Rnotex $a $p $t ↪
      H1 (λ (H4 : π ($p $t)),
             H2 (λ (z : Prop)
 		              (H3 : (Π (x : τ $a), π ($p x) → π z)),
-		      H3 $t H4))
+		      H3 $t H4));
 
 rule Rnotall $a $p ↪
   λ (H1 : (Π(t : τ $a), π (¬ ($p t)) → π ⊥))
     (H2 : π (¬ (@∀ $a $p))),
      H2 (λ (t : τ $a),
-	       nnpp ($p t) (H1 t))
+	       nnpp ($p t) (H1 t));
 
 // rule Rextype $p ↪
   // λ (H1 : (Π (a : Type), π ($p a) → π ⊥))
@@ -449,4 +454,4 @@ rule Rsubst $a $p $t1 $t2 ↪
     (H2 : (π ($p $t2) → π ⊥))
     (H3 : π ($p $t1)),
 	   H1 (λ (H4 : π (@equal $a $t1 $t2)),
-            H2 (H4 $p H3))
+            H2 (H4 $p H3));

--- a/zenon_focal.dk
+++ b/zenon_focal.dk
@@ -1,4 +1,7 @@
-#NAME focal.
+#REQUIRE cc.
+#REQUIRE dk_bool.
+#REQUIRE dk_logic.
+#REQUIRE zen.
 
 def bool := dk_bool.bool.
 def Bool := dk_bool.Bool.


### PR DESCRIPTION
The operator $ite_f(a,b,c) has been implemented as ((not a or b) and (a or c)) at the parser level, and the operator $ite_t(a,b,c) has been implemented as a polymorphic expression, similarly to the equality operator. However, I have not implemented a semantics for $ite_t.