### PR TITLE
Integers as formula names

### DIFF
--- a/parsetptp.mly
+++ b/parsetptp.mly
@@ -99,19 +99,15 @@ phrase:
   | INCLUDE OPEN LIDENT CLOSE DOT  { Phrase.Include ($3, None) }
   | INCLUDE OPEN LIDENT COMMA LBRACKET name_list RBRACKET CLOSE DOT
                                    { Phrase.Include ($3, Some ($6)) }
-  | INPUT_FORMULA OPEN LIDENT COMMA LIDENT COMMA formula extra CLOSE DOT
+  | INPUT_FORMULA OPEN name COMMA LIDENT COMMA formula extra CLOSE DOT
                                    { Phrase.Formula (ns_hyp $3, $5, $7, None) }
-  | INPUT_CLAUSE OPEN LIDENT COMMA LIDENT COMMA cnf_formula extra CLOSE DOT
+  | INPUT_CLAUSE OPEN name COMMA LIDENT COMMA cnf_formula extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, $5, cnf_to_formula $7, None) }
-  | INPUT_TFF_FORMULA OPEN LIDENT COMMA LIDENT COMMA formula COMMA LIDENT extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula COMMA LIDENT extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, Some $9) }
-  | INPUT_TFF_FORMULA OPEN LIDENT COMMA LIDENT COMMA formula extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
-  | INPUT_TFF_FORMULA OPEN LIDENT COMMA LIDENT COMMA type_def extra CLOSE DOT
-     { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
-  | INPUT_TFF_FORMULA OPEN INT COMMA LIDENT COMMA formula extra CLOSE DOT
-     { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
-  | INPUT_TFF_FORMULA OPEN INT COMMA LIDENT COMMA type_def extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA type_def extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
   | ANNOT                          { Phrase.Annotation $1 }
 ;
@@ -224,4 +220,8 @@ atom:
   | FALSE                          { efalse }
   | expr                           { $1 }
 ;
+
+name:
+  LIDENT { $1 }
+  |INT { "zenon_tptp_formula_" ^ $1 }
 %%


### PR DESCRIPTION
- Do not pollute output
- Removing quotes when opening include files
- Accept integers as formula names
