### PR TITLE
Fix TPTP syntax of annotations

### DIFF
--- a/lpprint.ml
+++ b/lpprint.ml
@@ -18,26 +18,23 @@ let escape_name s =
     then s else "{|" ^ s ^ "|}"
 
 
-let check_pvar v l = if List.mem v l then "&" ^ v else v
-let delete_pvar v l = List.filter (fun x -> x <> v) l
-
-let rec print_dk_type_aux o (t, l_rule) =
+let rec print_dk_type_aux o (t, var_context) =
   match t with
   | Dktypetype -> fprintf o "Type"
   | Dktypeprop -> fprintf o "Prop"
   | Dkarrow (l, r) ->
      begin
-       List.iter (fun x -> fprintf o "%a → " print_dk_type_aux (x, l_rule)) l;
-       print_dk_type_aux o (r, l_rule);
+       List.iter (fun x -> fprintf o "%a → " print_dk_type_aux (x, var_context)) l;
+       print_dk_type_aux o (r, var_context);
      end
   | Dkpi (Dkvar (_, t1) as var, t2) ->
   let pvar = escape_name (get_var_newname var) in
       fprintf o "Π (%s : %a),\n %a"
-	      pvar print_dk_type_aux (t1, l_rule) print_dk_type_aux (t2, delete_pvar pvar l_rule)
+	      pvar print_dk_type_aux (t1, var_context) print_dk_type_aux (t2, pvar::var_context)
   | Dkpi _ -> assert false
   | Dkproof (t) ->
-     fprintf o "ϵ (%a)" print_dk_term_aux (t, l_rule)
-  | t -> fprintf o "τ (%a)" print_dk_zentype_aux (t, l_rule)
+     fprintf o "ϵ (%a)" print_dk_term_aux (t, var_context)
+  | t -> fprintf o "τ (%a)" print_dk_zentype_aux (t, var_context)
 and print_dk_type o t = print_dk_type_aux o (t, [])
 and print_dk_zentype_aux o (t, l) =
   match t with
@@ -57,211 +54,213 @@ and print_dk_cst o t =
           fprintf o " %s" !Globals.neg_conj
       end
 
-and print_dk_term_aux o (t, l_rule) =
+and print_dk_term_aux o (t, var_context) =
   match t with
-  | Dkvar (_, _) as var ->
-      let pvar = (escape_name (get_var_newname var)) in
-      fprintf o "%s" (check_pvar pvar l_rule)
+  | Dkvar (v, _) as var ->
+    let pvar = (escape_name (get_var_newname var)) in
+    if not (List.mem pvar var_context)
+    then fprintf o "select ι"
+    else fprintf o "%s" pvar
  | Dklam (Dkvar (_, t1) as var, t2) ->
       let pvar = (escape_name (get_var_newname var)) in
      fprintf o "λ (%s : %a),\n %a"
 	     pvar
-	     print_dk_type_aux (t1, l_rule) print_dk_term_aux (t2, (delete_pvar pvar l_rule))
+	     print_dk_type_aux (t1, var_context) print_dk_term_aux (t2, (pvar::var_context))
   | Dklam (Dkapp (v, t1, []), t2) ->
       let pvar = escape_name v in
      fprintf o "λ (%s : %a),\n %a"
-	     pvar print_dk_type_aux (t1, l_rule) print_dk_term_aux (t2, (delete_pvar pvar l_rule))
+	     pvar print_dk_type_aux (t1, var_context) print_dk_term_aux (t2, (pvar::var_context))
   | Dklam _ -> assert false
   | Dkapp (v, _, l) ->
      begin
        print_dk_cst o v;
-       List.iter (fun x -> fprintf o " (%a)" print_dk_term_aux (x, l_rule)) l;
+       List.iter (fun x -> fprintf o " (%a)" print_dk_term_aux (x, var_context)) l;
 (*       fprintf o "\n ";*)
      end
   | Dkseq -> fprintf o "ϵ ⊥"
   | Dknot (t) ->
-     fprintf o "¬\n (%a)" print_dk_term_aux  (t, l_rule)
+     fprintf o "¬\n (%a)" print_dk_term_aux  (t, var_context)
   | Dkand (t1, t2) ->
-     fprintf o "(%a)\n∧\n(%a)\n" print_dk_term_aux (t1, l_rule) print_dk_term_aux (t2, l_rule)
+     fprintf o "(%a)\n∧\n(%a)\n" print_dk_term_aux (t1, var_context) print_dk_term_aux (t2, var_context)
   | Dkor (t1, t2) ->
-     fprintf o "(%a)\n∨\n(%a)\n" print_dk_term_aux (t1, l_rule) print_dk_term_aux (t2, l_rule)
+     fprintf o "(%a)\n∨\n(%a)\n" print_dk_term_aux (t1, var_context) print_dk_term_aux (t2, var_context)
   | Dkimply (t1, t2) ->
-     fprintf o "(%a)\n⇒\n(%a)\n" print_dk_term_aux (t1, l_rule) print_dk_term_aux (t2, l_rule)
+     fprintf o "(%a)\n⇒\n(%a)\n" print_dk_term_aux (t1, var_context) print_dk_term_aux (t2, var_context)
   | Dkequiv (t1, t2) ->
-     fprintf o "(%a)\n⇔\n(%a)\n" print_dk_term_aux (t1, l_rule) print_dk_term_aux (t2, l_rule)
+     fprintf o "(%a)\n⇔\n(%a)\n" print_dk_term_aux (t1, var_context) print_dk_term_aux (t2, var_context)
   | Dkforall (_, t2) ->
-     fprintf o "∀α (%a)" print_dk_term_aux (t2, l_rule)
-     (* fprintf o "@∀ (%a)\n (%a)" print_dk_zentype_aux (t1, l_rule) print_dk_term_aux (t2, l_rule) *)
+     fprintf o "∀α (%a)" print_dk_term_aux (t2, var_context)
+     (* fprintf o "@∀ (%a)\n (%a)" print_dk_zentype_aux (t1, var_context) print_dk_term_aux (t2, var_context) *)
   | Dkexists (_, t2) ->
-     fprintf o "∃α (%a)" print_dk_term_aux (t2, l_rule)
-     (* fprintf o "@∃ (%a)\n (%a)" print_dk_zentype_aux  (t1, l_rule) print_dk_term_aux (t2, l_rule) *)
+     fprintf o "∃α (%a)" print_dk_term_aux (t2, var_context)
+     (* fprintf o "@∃ (%a)\n (%a)" print_dk_zentype_aux  (t1, var_context) print_dk_term_aux (t2, var_context) *)
   | Dkforalltype (t) ->
-     fprintf o "foralltype\n (%a)" print_dk_term_aux (t, l_rule)
+     fprintf o "foralltype\n (%a)" print_dk_term_aux (t, var_context)
   | Dkexiststype (t) ->
-     fprintf o "existstype\n (%a)" print_dk_term_aux (t, l_rule)
+     fprintf o "existstype\n (%a)" print_dk_term_aux (t, var_context)
   | Dktrue -> fprintf o "⊤"
   | Dkfalse -> fprintf o "⊥"
   | Dkequal (_, t2, t3) ->
      fprintf o "(%a) =α (%a)"
-	     print_dk_term_aux (t2, l_rule)
-	     print_dk_term_aux (t3, l_rule)
-  | DkRfalse (pr) -> fprintf o "Rfalse\n (%a)" print_dk_term_aux (pr, l_rule)
-  | DkRnottrue (pr) -> fprintf o "Rnottrue\n (%a)" print_dk_term_aux (pr, l_rule)
+	     print_dk_term_aux (t2, var_context)
+	     print_dk_term_aux (t3, var_context)
+  | DkRfalse (pr) -> fprintf o "Rfalse\n (%a)" print_dk_term_aux (pr, var_context)
+  | DkRnottrue (pr) -> fprintf o "Rnottrue\n (%a)" print_dk_term_aux (pr, var_context)
   | DkRaxiom (p, pr1, pr2) ->
      fprintf o "Raxiom\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnoteq (a, t, pr) ->
      fprintf o "Rnoteq\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (t, l_rule)
-	     print_dk_term_aux (pr, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (t, var_context)
+	     print_dk_term_aux (pr, var_context)
   | DkReqsym (a, t, u, pr1, pr2) ->
      fprintf o "Reqsym\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (t, l_rule)
-	     print_dk_term_aux (u, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (t, var_context)
+	     print_dk_term_aux (u, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRcut (p, pr1, pr2) ->
      fprintf o "Rcut\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnotnot (p, pr1, pr2) ->
      fprintf o "Rnotnot\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRand (p, q, pr1, pr2) ->
      fprintf o "Rand\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRor (p, q, pr1, pr2, pr3) ->
      fprintf o "Ror\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | DkRimply (p, q, pr1, pr2, pr3) ->
      fprintf o "Rimply\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | DkRequiv (p, q, pr1, pr2, pr3) ->
      fprintf o "Requiv\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | DkRnotand (p, q, pr1, pr2, pr3) ->
      fprintf o "Rnotand\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | DkRnotor (p, q, pr1, pr2) ->
      fprintf o "Rnotor\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnotimply (p, q, pr1, pr2) ->
      fprintf o "Rnotimply\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnotequiv (p, q, pr1, pr2, pr3) ->
      fprintf o "Rnotequiv\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (q, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (q, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | DkRex (a, p, pr1, pr2) ->
      fprintf o "Rex\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRall (a, p, t, pr1, pr2) ->
      fprintf o "Rall\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (t, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (t, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnotex (a, p, t, pr1, pr2) ->
      fprintf o "Rnotex\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (t, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (t, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnotall (a, p, pr1, pr2) ->
      fprintf o "Rnotall\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRextype (p, pr1, pr2) ->
      fprintf o "Rextype\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRalltype (p, a, pr1, pr2) ->
      fprintf o "Ralltype\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnotextype (p, a, pr1, pr2) ->
      fprintf o "Rnotextype\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRnotalltype (p, pr1, pr2) ->
      fprintf o "Rnotalltype\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
   | DkRsubst  (a, p, t1, t2, pr1, pr2, pr3) ->
      fprintf o "Rsubst\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (t1, l_rule)
-	     print_dk_term_aux (t2, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (t1, var_context)
+	     print_dk_term_aux (t2, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | DkRconglr (a, p, t1, t2, pr1, pr2, pr3) ->
      fprintf o "Rconglr\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (t1, l_rule)
-	     print_dk_term_aux (t2, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (t1, var_context)
+	     print_dk_term_aux (t2, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | DkRcongrl (a, p, t1, t2, pr1, pr2, pr3) ->
      fprintf o "Rcongrl\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n (%a)\n"
-	     print_dk_zentype_aux (a, l_rule)
-	     print_dk_term_aux (p, l_rule)
-	     print_dk_term_aux (t1, l_rule)
-	     print_dk_term_aux (t2, l_rule)
-	     print_dk_term_aux (pr1, l_rule)
-	     print_dk_term_aux (pr2, l_rule)
-	     print_dk_term_aux (pr3, l_rule)
+	     print_dk_zentype_aux (a, var_context)
+	     print_dk_term_aux (p, var_context)
+	     print_dk_term_aux (t1, var_context)
+	     print_dk_term_aux (t2, var_context)
+	     print_dk_term_aux (pr1, var_context)
+	     print_dk_term_aux (pr2, var_context)
+	     print_dk_term_aux (pr3, var_context)
   | _ -> assert false
  and print_dk_term o t = print_dk_term_aux o (t, [])
 

--- a/parsetptp.mly
+++ b/parsetptp.mly
@@ -99,19 +99,15 @@ phrase:
   | INCLUDE OPEN LIDENT CLOSE DOT  { Phrase.Include ($3, None) }
   | INCLUDE OPEN LIDENT COMMA LBRACKET name_list RBRACKET CLOSE DOT
                                    { Phrase.Include ($3, Some ($6)) }
-  | INPUT_FORMULA OPEN LIDENT COMMA LIDENT COMMA formula extra CLOSE DOT
+  | INPUT_FORMULA OPEN name COMMA LIDENT COMMA formula extra CLOSE DOT
                                    { Phrase.Formula (ns_hyp $3, $5, $7, None) }
-  | INPUT_CLAUSE OPEN LIDENT COMMA LIDENT COMMA cnf_formula extra CLOSE DOT
+  | INPUT_CLAUSE OPEN name COMMA LIDENT COMMA cnf_formula extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, $5, cnf_to_formula $7, None) }
-  | INPUT_TFF_FORMULA OPEN LIDENT COMMA LIDENT COMMA formula COMMA LIDENT extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula COMMA LIDENT extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, Some $9) }
-  | INPUT_TFF_FORMULA OPEN LIDENT COMMA LIDENT COMMA formula extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
-  | INPUT_TFF_FORMULA OPEN LIDENT COMMA LIDENT COMMA type_def extra CLOSE DOT
-     { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
-  | INPUT_TFF_FORMULA OPEN INT COMMA LIDENT COMMA formula extra CLOSE DOT
-     { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
-  | INPUT_TFF_FORMULA OPEN INT COMMA LIDENT COMMA type_def extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA type_def extra CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
   | ANNOT                          { Phrase.Annotation $1 }
 ;
@@ -224,4 +220,8 @@ atom:
   | FALSE                          { efalse }
   | expr                           { $1 }
 ;
+
+name:
+  LIDENT { $1 }
+  |INT { "zenon_tptp_formula_" ^ $1 }
 %%

--- a/parsetptp.mly
+++ b/parsetptp.mly
@@ -99,27 +99,63 @@ phrase:
   | INCLUDE OPEN LIDENT CLOSE DOT  { Phrase.Include ($3, None) }
   | INCLUDE OPEN LIDENT COMMA LBRACKET name_list RBRACKET CLOSE DOT
                                    { Phrase.Include ($3, Some ($6)) }
-  | INPUT_FORMULA OPEN name COMMA LIDENT COMMA formula extra CLOSE DOT
+  | INPUT_FORMULA OPEN name COMMA LIDENT COMMA formula annotations CLOSE DOT
                                    { Phrase.Formula (ns_hyp $3, $5, $7, None) }
-  | INPUT_CLAUSE OPEN name COMMA LIDENT COMMA cnf_formula extra CLOSE DOT
+  | INPUT_CLAUSE OPEN name COMMA LIDENT COMMA cnf_formula annotations CLOSE DOT
      { Phrase.Formula (ns_hyp $3, $5, cnf_to_formula $7, None) }
-  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula COMMA LIDENT extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula COMMA LIDENT annotations CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, Some $9) }
-  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA formula annotations CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
-  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA type_def extra CLOSE DOT
+  | INPUT_TFF_FORMULA OPEN name COMMA LIDENT COMMA type_def annotations CLOSE DOT
      { Phrase.Formula (ns_hyp $3, "tff_" ^ $5, $7, None) }
   | ANNOT                          { Phrase.Annotation $1 }
 ;
-extra:
+annotations:
   | {}
-  | COMMA extra_expr extra {}
+  | COMMA source optional_info {}
 ;
-extra_expr:
-  | expr {}
-  | LBRACKET extra_expr extra RBRACKET {}
-  | LIDENT OPEN LIDENT extra CLOSE {}
+
+source:
+general_term {}
 ;
+
+general_term:
+general_data {}
+  | general_data COLON general_term {}
+  | general_list {}
+;
+
+general_data:
+LIDENT {}
+  | general_function {}
+  | UIDENT {}
+  | INT {}
+  | RAT {}
+  | REAL {}
+  | STRING {}
+/* | formula_data {} unsupported */
+;
+
+general_function:
+LIDENT OPEN general_terms CLOSE {}
+;
+
+general_terms:
+general_term {}
+  | general_term COMMA general_terms {}
+;
+
+general_list:
+LBRACKET RBRACKET {}
+  | LBRACKET general_terms RBRACKET {}
+;
+
+optional_info:
+COMMA general_list {}
+  | {}
+;
+
 expr:
   | UIDENT                             { tvar_none (ns_var $1) }
   | LIDENT arguments                   { eapp (tvar_none @@ ns_fun $1, $2) }


### PR DESCRIPTION
- Accept integers as formula names
- Fix bug where a free variable was printed in the proof term.
- More close to real TPTP syntax of annotations. (Still missing: formula_data, and semantic verification.)
