### PR TITLE
Also handling the not forall case with epsilon terms

### DIFF
--- a/dkterm.ml
+++ b/dkterm.ml
@@ -55,6 +55,7 @@ type dkterm =
   | DkRconglr       of dkterm * dkterm * dkterm * dkterm * dkterm * dkterm * dkterm
   | DkRcongrl       of dkterm * dkterm * dkterm * dkterm * dkterm * dkterm * dkterm
   | DkReps          of dkterm * dkterm * dkterm * dkterm
+  | DkRnoteps       of dkterm * dkterm * dkterm * dkterm
 ;;
 
 type line =
@@ -147,6 +148,7 @@ let mk_DkRsubst        (a, p, t1, t2, pr1, pr2, pr3)  = DkRsubst (a, p, t1, t2, 
 let mk_DkRconglr       (a, p, t1, t2, pr1, pr2, pr3)  = DkRconglr (a, p, t1, t2, pr1, pr2, pr3)
 let mk_DkRcongrl       (a, p, t1, t2, pr1, pr2, pr3)  = DkRcongrl (a, p, t1, t2, pr1, pr2, pr3)
 let mk_DkReps          (a, p, pr1, pr2)  = DkReps (a, p, pr1, pr2)
+let mk_DkRnoteps       (a, p, pr1, pr2)  = DkRnoteps (a, p, pr1, pr2)
 
 let mk_decl       (v, t)       = Dkdecl (v, t)
 let mk_rwrt       (l, t1, t2)  = Dkrwrt (l, t1, t2)

--- a/dkterm.mli
+++ b/dkterm.mli
@@ -56,6 +56,7 @@ type dkterm =
   | DkRconglr       of dkterm * dkterm * dkterm * dkterm * dkterm * dkterm * dkterm
   | DkRcongrl       of dkterm * dkterm * dkterm * dkterm * dkterm * dkterm * dkterm
   | DkReps          of dkterm * dkterm * dkterm * dkterm (* type, predicate, proof of eps, proof of ex *)
+  | DkRnoteps          of dkterm * dkterm * dkterm * dkterm (* type, predicate, proof of eps, proof of ex *)
 
 type line =
   | Dkdecl of var * dkterm                     (* declaration of symbols *)
@@ -87,7 +88,7 @@ val mk_existstype       : dkterm -> dkterm
 val mk_true             : dkterm
 val mk_false            : dkterm
 val mk_equal            : dkterm * dkterm * dkterm -> dkterm
-val mk_eps       : dkterm -> dkterm
+val mk_eps              : dkterm -> dkterm
 
 val mk_DkRfalse         : dkterm -> dkterm
 val mk_DkRnottrue       : dkterm -> dkterm
@@ -115,7 +116,8 @@ val mk_DkRnotalltype    : dkterm * dkterm * dkterm -> dkterm
 val mk_DkRsubst         : dkterm * dkterm * dkterm * dkterm * dkterm * dkterm * dkterm -> dkterm
 val mk_DkRconglr        : dkterm * dkterm * dkterm * dkterm * dkterm * dkterm * dkterm -> dkterm
 val mk_DkRcongrl        : dkterm * dkterm * dkterm * dkterm * dkterm * dkterm * dkterm -> dkterm
-val mk_DkReps            : dkterm * dkterm * dkterm * dkterm -> dkterm
+val mk_DkReps           : dkterm * dkterm * dkterm * dkterm -> dkterm
+val mk_DkRnoteps        : dkterm * dkterm * dkterm * dkterm -> dkterm
 
 val mk_decl             : var * dkterm -> line
 val mk_rwrt             : dkterm list * dkterm * dkterm -> line

--- a/lltolp.ml
+++ b/lltolp.ml
@@ -603,9 +603,13 @@ let rec trproof_dk p =
 	  let pzz = substitute [(vx, zz)] px in
 	  let prpzz = mk_pr_var (enot pzz) in
 	  let sub = trproof_dk (List.nth phyps 0) in
-	  let lam = mk_lam (dkzz, mk_lam (prpzz, sub)) in
 	  let conc = get_pr_var (enot allp) in
-	  mk_DkRnotall (a, dkp, lam, conc)
+	  if !Globals.epsilon_on_input then
+            let lam = mk_lam (prpzz, sub) in
+	    mk_DkRnoteps (a, dkp, lam, conc)
+          else
+            let lam = mk_lam (dkzz, mk_lam (prpzz, sub)) in
+	    mk_DkRnotall (a, dkp, lam, conc)
      | Rpnotp ((Eapp (Evar (p, _), args1, _) as pp),
 	       (Enot (Eapp (Evar (q, _), args2, _) as qq, _))) ->
 	assert (p == q);
@@ -1041,7 +1045,10 @@ let output oc phrases llp =
   let prooftree = extract_prooftree llp in
   let dkproof = make_proof_term (List.hd goal) prooftree in
   fprintf oc "require open Stdlib.Prop Stdlib.Set Stdlib.Eq Stdlib.FOL \
-              Logic.Zenon.Main;\n\n";
+              Logic.Zenon.Main;\n";
+  if !Globals.epsilon_on_input then
+    fprintf oc "require open Logic.Zenon.Main_Epsilon;\n";
+  fprintf oc "\n";
   if !Globals.signature_name = "" then List.iter (print_line oc) dksigs;
   fprintf oc "\n";
   if !Globals.signature_name = "" then List.iter (print_line oc) dkctx;
@@ -1071,6 +1078,8 @@ let output_term oc phrases _ llp =
   let dkproof = make_proof_term (List.hd goal) prooftree in
   fprintf oc "require open Stdlib.Prop Stdlib.Set Stdlib.Eq Stdlib.FOL \
               Logic.Zenon.Main;\n";
+  if !Globals.epsilon_on_input then
+    fprintf oc "require open Logic.Zenon.Main_Epsilon;\n";
   if !Globals.gdv then
     fprintf oc "\nrule F.%s ↪ " goal_name
   else

--- a/lpprint.ml
+++ b/lpprint.ml
@@ -335,6 +335,12 @@ and print_dk_term_aux o (t, var_context) =
        print_dk_term_aux (p, var_context)
        print_dk_term_aux (pr1, var_context)
        print_dk_term_aux (pr2, var_context)
+  | DkRnoteps (a, p, pr1, pr2) ->
+     fprintf o "Rnoteps\n (%a)\n (%a)\n (%a)\n (%a)\n"
+       print_dk_zentype_aux (a, var_context)
+       print_dk_term_aux (p, var_context)
+       print_dk_term_aux (pr1, var_context)
+       print_dk_term_aux (pr2, var_context)
   | _ -> assert false
  and print_dk_term o t = print_dk_term_aux o (t, [])
 


### PR DESCRIPTION
When epsilon-terms are present on the input, use a special rule based on the epsilon axiom.

Need to require Logic.Zenon.Main_Epsilon to get the new rules.
